### PR TITLE
support enum and union; nonempty for fields

### DIFF
--- a/src/Language/C99/Simple/AST.hs
+++ b/src/Language/C99/Simple/AST.hs
@@ -11,6 +11,7 @@
 module Language.C99.Simple.AST where
 
 import Prelude hiding (LT, GT)
+import Data.List.NonEmpty (NonEmpty)
 
 type Ident    = String
 
@@ -85,7 +86,13 @@ data TypeSpec = Void
               | TypedefName Ident
 
               | Struct      Ident
-              | StructDecln (Maybe Ident) [FieldDecln]
+              | StructDecln (Maybe Ident) (NonEmpty FieldDecln)
+
+              | Union      Ident
+              | UnionDecln (Maybe Ident) (NonEmpty FieldDecln)
+
+              | Enum      Ident
+              | EnumDecln (Maybe Ident) (NonEmpty Ident)
 
 data FieldDecln = FieldDecln Type Ident
 


### PR DESCRIPTION
enums and unions can now be expressed.

Also changed the struct declarations to take at least one field, as it seems that's always been required by `language-c99` (and presumably by the C99 spec?).