### PR TITLE
Use https instead of git:// for source url

### DIFF
--- a/language-c99-simple.cabal
+++ b/language-c99-simple.cabal
@@ -22,7 +22,7 @@ cabal-version:       >=1.10
 
 source-repository head
   type:     git
-  location: git://github.com:fdedden/language-c99-simple.git
+  location: https://github.com/fdedden/language-c99-simple.git
 
 library
   exposed-modules:    Language.C99.Simple,


### PR DESCRIPTION
`git://` is no longer supported.