### PR TITLE
Extend FunDef with an optional StorageSpec. Refs #22.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Revision history for language-c99-simple
 
+## 0.3.0 -- TBD
+
+
 ## 0.2.3 -- 2023-08-30
 
 * Allow building with mtl-2.3.1 (thanks RyanGlScott) (#15).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## 0.3.0 -- TBD
 
+* Extend FunDef with an optional StorageSpec. (thanks ivanperez-keera) (#23).
 
 ## 0.2.3 -- 2023-08-30
 

--- a/src/Language/C99/Simple/AST.hs
+++ b/src/Language/C99/Simple/AST.hs
@@ -17,7 +17,7 @@ type Ident    = String
 
 data TransUnit = TransUnit [Decln] [FunDef]
 
-data FunDef = FunDef Type Ident [Param] [Decln] [Stmt]
+data FunDef = FunDef (Maybe StorageSpec) Type Ident [Param] [Decln] [Stmt]
 
 data Param = Param Type Ident
 

--- a/src/Language/C99/Simple/Translate.hs
+++ b/src/Language/C99/Simple/Translate.hs
@@ -21,9 +21,9 @@ transtransunit (TransUnit declns fundefs) = fromList (declns' ++ fundefs') where
   fundefs' = map (C.ExtFun   . transfundef) fundefs
 
 transfundef :: FunDef -> C.FunDef
-transfundef (FunDef ty name params decln ss) =
+transfundef (FunDef storespec ty name params decln ss) =
   C.FunDef dspecs declr Nothing body where
-    dspecs   = getdeclnspecs Nothing ty
+    dspecs   = getdeclnspecs storespec ty
     body     = compound decln ss
     declr    = execState (getdeclr ty) fundeclr
     fundeclr = C.Declr Nothing (fundirectdeclr name params)


### PR DESCRIPTION
Unlike `FunDecln`, which is defined as:

```
FunDecl (Maybe StorageSpec) Type Ident [Param]
```

a `FunDef` does not include a `StorageSpec` (optional or not):

```
FunDef Type Ident [Param] [Decln] [Stmt]
```

This prevents us from adding the keyword `static` to local functions, which is a requirement for compliance with MISRA C 2012 in Copilot.

This commit modifies `FunDef` to have an optional `StorageSpec` as well.