### PR TITLE
Use https instead of git:// for source url

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## 0.3.0 -- TBD
 
+* Use https instead of git:// for source url (thanks felixonmars) (#24).
 * Extend FunDef with an optional StorageSpec. (thanks ivanperez-keera) (#23).
 
 ## 0.2.3 -- 2023-08-30

--- a/language-c99-simple.cabal
+++ b/language-c99-simple.cabal
@@ -22,7 +22,7 @@ cabal-version:       >=1.10
 
 source-repository head
   type:     git
-  location: git://github.com:fdedden/language-c99-simple.git
+  location: https://github.com/fdedden/language-c99-simple.git
 
 library
   exposed-modules:    Language.C99.Simple,


### PR DESCRIPTION
`git://` is not public anymore on Github (https://github.blog/2021-09-01-improving-git-protocol-security-github/).

Supersedes #20.